### PR TITLE
Add OpenSearch description

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <link rel="shortcut icon" href="images/favicon.png" type="image/x-icon">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+    <link rel="search" type="application/opensearchdescription+xml" title="Home Manager - Option Search" href="opensearch.xml" />
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
     <script async defer data-website-id="58f01126-9377-43dc-aec9-25a9091ecf20" src="https://umami.poppygo.io/umami.js"></script>

--- a/opensearch.xml
+++ b/opensearch.xml
@@ -1,0 +1,9 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
+                       xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <ShortName>Home Manager - Options Search</ShortName>
+  <Description>Find home manager options quickly.</Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Image width="16" height="16" type="image/x-icon">https://mipmip.github.io/home-manager-option-search/images/favicon.png</Image>
+  <Url type="text/html" template="https://mipmip.github.io/home-manager-option-search/?query={searchTerms}"/>
+  <moz:SearchForm>https://mipmip.github.io/home-manager-option-search/</moz:SearchForm>
+</OpenSearchDescription>


### PR DESCRIPTION
This makes it possible to add the site as a search engine in Firefox and other browsers that support the [OpenSearch description format](https://github.com/dewitt/opensearch)

Fixes #12
