### PR TITLE
Add a 100ms debounce to the search input

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -140,11 +140,19 @@ var searchOptions = function(query) {
   updateOptionCountAndTable();
 };
 
-searchInput.oninput =  function () {
-  const query = searchInput.value;
-  setSearchQueryToUrlParam(query);
-  searchOptions(query);
-}
+const SEARCH_INPUT_DEBOUNCE_MS = 100;
+
+let debounceTimer;
+
+searchInput.oninput = function() {
+  clearTimeout(debounceTimer);
+
+  debounceTimer = setTimeout(() => {
+    const query = searchInput.value;
+    setSearchQueryToUrlParam(query);
+    searchOptions(query);
+  }, SEARCH_INPUT_DEBOUNCE_MS);
+};
 
 var updateOptionCount = function(numOptions) {
   optionCountBadge.innerText = numOptions + ' options';


### PR DESCRIPTION
Adding a minor debounce greatly improves the typing experience of the search bar.

Here's a recording with the debounce:

https://github.com/mipmip/home-manager-option-search/assets/16181067/646c6b58-3162-4ad7-8460-1e8b38fdc95d

Here's a recording without the debounce:

https://github.com/mipmip/home-manager-option-search/assets/16181067/4c986faf-eeff-44d1-91f6-6147f06c7554

It's a bit hard to see in a video, but the input element lags behind what I'm typing because the browser is running your JavaScript for each keypress. I would recommend spinning up the app and testing it to see for yourself.

Thanks for this project, I use it almost daily!