### PR TITLE
Fix Deployment

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.3
           #bundler-cache: true
 
       - run: |

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    mini_portile2 (2.6.1)
-    nokogiri (1.12.5)
-      mini_portile2 (~> 2.6.1)
+    mini_portile2 (2.8.5)
+    nokogiri (1.16.2)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    racc (1.6.0)
+    racc (1.7.3)
 
 PLATFORMS
   ruby

--- a/scripts/parse_appendix.rb
+++ b/scripts/parse_appendix.rb
@@ -3,7 +3,7 @@ require 'nokogiri'
 require 'json'
 require 'pp'
 
-url = 'https://nix-community.github.io/home-manager/options.html'
+url = 'https://nix-community.github.io/home-manager/options.xhtml'
 html=""
 URI.open(url) do |f|
   html = f.read

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,7 @@
 with (import <nixpkgs> {});
 mkShell {
   buildInputs = [
-    ruby_2_7
+    ruby_3_3
   ];
   shellHook = ''
     mkdir -p .nix-gems


### PR DESCRIPTION
Hey!

I've noticed that the website wasn't being updated anymore since December 15th and then saw that the workflows had been failing for two months since this one: https://github.com/mipmip/home-manager-option-search/actions/runs/7229761137 because `gem install bundler` required ruby > 3.0, so I went ahead and updated the dependencies and ruby version (which also fixes the shell.nix, which didn't work anymore in nixos-unstable because ruby_2_7 was removed).

The second fix is that home manager changed their options url from 
https://nix-community.github.io/home-manager/options.html to
https://nix-community.github.io/home-manager/options.xhtml

so I changed that as well, and now everything is working again:
https://arminius-smh.github.io/home-manager-option-search/