### PR TITLE
Fix null query parameter

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -14,7 +14,7 @@ var rebuildAndRerunSearch = function() {
 
 var docOnload = function(){
   const urlParams = new URLSearchParams(window.location.search);
-  const query = urlParams.get('query');
+  const query = urlParams.get('query') ?? '';
   searchInput.value = query;
   searchOptions(query);
 


### PR DESCRIPTION
https://github.com/mipmip/home-manager-option-search/pull/23 introduced a small bug where if you go to the website without having the query parameter set (just https://mipmip.github.io/home-manager-option-search/), then no options will be shown due to 
```js
if (query.length > 1)
```
failing in the searchOptions function. This default value makes sure that query isn't null.