### PR TITLE
fix page reload on enter

### DIFF
--- a/themes/extranix-options-search/layouts/index.html
+++ b/themes/extranix-options-search/layouts/index.html
@@ -75,7 +75,7 @@
       </div>
 
       <div id="searchform" xstyle="background-color: white;top:54px;position:sticky;">
-        <form method="get" action="?" onSubmit="searchEnter()">
+        <form method="get" onSubmit="return false;">
           <div class="form-group">
             <label for="searchInput">
               Option Search


### PR DESCRIPTION
This makes it so pressing enter in the `searchInput` input no longer reloads the page.

The `searchEnter` function was already removed in #9.