### PR TITLE
Add Nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1723637854,
+        "narHash": "sha256-med8+5DSWa2UnOqtdICndjDAEjxr5D7zaIiK4pn0Q7c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c3aa7b8938b17aebd2deecf7be0636000d62a2b9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  description = "Home Manager option search static website generator";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs, ... }:
+    let
+      forAllSystems = nixpkgs.lib.genAttrs [ "x86_64-linux" ];
+      pkgsForSystem = system: (import nixpkgs { inherit system; });
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = (pkgsForSystem system);
+        in
+        {
+          default = pkgs.runCommand "public" {} ''
+            cd ${./.}
+            ${pkgs.hugo}/bin/hugo --noBuildLock -d $out
+          '';
+        });
+
+      devShells = forAllSystems (system: {
+        default = (pkgsForSystem system).mkShell {
+          buildInputs = with (pkgsForSystem system); [
+            hugo
+            ruby
+          ];
+        };
+      });
+    };
+}


### PR DESCRIPTION
This patch adds a `flake.nix` to home-manager-option-search.

This enables to quickly build the website using `nix build .` and to get a shell with Hugo and Ruby using `nix develop .`.
This makes it simpler for flake users to deploy home-manager-option-search on their infra and follow updates.