### PR TITLE
Escape <> in option names by using textContent

### DIFF
--- a/themes/extranix-options-search/static/js/script.js
+++ b/themes/extranix-options-search/static/js/script.js
@@ -52,7 +52,7 @@ var releaseSelect = document.getElementById('releaseSelect');
 var optionCountBadge = document.getElementById('optionCountBadge');
 
 var updateLastUpdate = function(lastUpdate) {
-  lastUpdateElement.innerHTML = 'Last update: '+ lastUpdate;
+  lastUpdateElement.textContent = 'Last update: '+ lastUpdate;
 };
 
 var updateOptionsTable = function(options) {
@@ -65,14 +65,14 @@ var updateOptionsTable = function(options) {
     var option = options[i];
 
     var titleColumn = document.createElement('td');
-    titleColumn.innerHTML = option.title;
+    titleColumn.textContent = option.title;
 
     var descriptionColumn = document.createElement('td');
-    descriptionColumn.innerHTML = option.description;
+    descriptionColumn.textContent = option.description;
     descriptionColumn.classList.add("phonehide");
 
     var typeColumn = document.createElement('td');
-    typeColumn.innerHTML = option.type;
+    typeColumn.textContent = option.type;
     typeColumn.classList.add("phonehide");
 
     var tableRow = document.createElement('tr');
@@ -119,7 +119,7 @@ function parseDescription(text){
 
 var expandOption = function(el){
 
-  modalTitle.innerHTML = currentSet[el].title;
+  modalTitle.textContent = currentSet[el].title;
 
   //console.log(currentSet[el].description.replace(/:::\ \{\.note\}(\s*([^:::]*))/gi ,'<div class="alert alert-info" role="alert">$1</div>').replace(/:::/,''));
 


### PR DESCRIPTION
Many home-manager options use `<name>` as a convention for attribute set keys, which was being interpreted as HTML when served to the client. By using `textContent` instead of `innerHTML`, these names will be rendered more correctly and avoid any odd behavior from being treated as HTML tags.

There might be some other cases (like defaults / examples) that might benefit from this, but I think this covers the main cases.

### Before
![Screenshot 2024-08-19 at 10 47 35](https://github.com/user-attachments/assets/1fc0795f-1a1e-4201-b754-ea2dbb29177f)
![Screenshot 2024-08-19 at 10 47 39](https://github.com/user-attachments/assets/a169596e-8310-440f-a824-97b345c5cf29)

### After 
![Screenshot 2024-08-19 at 10 47 19](https://github.com/user-attachments/assets/7247a8b1-7620-4370-a464-01a2c5acfda4)
![Screenshot 2024-08-19 at 10 47 26](https://github.com/user-attachments/assets/5124ddcd-a1ff-45c3-802c-230233a20b8b)
