### PR TITLE
pad bottom of table to ensure no content is hidden

### DIFF
--- a/themes/extranix-options-search/layouts/index.html
+++ b/themes/extranix-options-search/layouts/index.html
@@ -54,7 +54,7 @@
     </header>
 
 
-    <div class="xcontainer" style="padding-top:70px;">
+    <div class="xcontainer" style="padding-top:70px; padding-bottom:47px;">
       <!-- Modal -->
 
       <div class="modal" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">


### PR DESCRIPTION
fixes #46

the way that @JaSpa recommended fixing works as well, will implement it instead that way if you'd like. I don't like how it makes the footer move when you hit the bottom of the page though, so I did this instead.

I'm also not sure of best webdev practices, so if you'd like this defined in `style-q2.css` instead, I will.