### PR TITLE
workflow: '24.05' -> 'stable'

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -23,9 +23,9 @@ jobs:
       - name: update gitignore
         run: echo result > .gitignore
 
-      - name: extract-options-release-24.05 (stable)
+      - name: extract-options-release (stable)
         env:
-          HM_RELEASE: release-24.05
+          HM_RELEASE: stable
         run: ./scripts/build_and_parse_hm_options.rb
 
       - name: Build Hugo


### PR DESCRIPTION
The expected flow in the build script was not followed. I'm not sure if
this was a mistake or if the intentions changed later on, but
`./scripts/build_and_parse_hm_options.rb` checked for [`HM_RELEASE`](https://github.com/mipmip/home-manager-option-search/blob/main/scripts/build_and_parse_hm_options.rb#L40) to be
'stable' to then use the branch referenced in [`./config.yaml`](https://github.com/mipmip/home-manager-option-search/blob/main/config.yaml#L8) under the
`release_current_stable` key. Based on the instructions for updating the
stable branch reference, this is what is intended. The workflow however
doesn't have this mapped correctly, rather `release-24.05` is being
built explicitly, rather than "stable".

Although `release-24.11` was added, its docs were never actually built.
This has been corrected here to follow what I interpret as the intended
workflow. If it is preferred to simply update the workflow manually to
point to the new version each time, then the `README` can be updated to indicate this.
