### PR TITLE
Add release-25.05 json generation to GH action

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -23,14 +23,14 @@ jobs:
       - name: update gitignore
         run: echo result > .gitignore
 
-      - name: extract-options-release-24.11 (new-stable)
+      - name: extract-options-release-25.05 (stable)
         env:
-          HM_RELEASE: release-24.11
+          HM_RELEASE: release-25.05
         run: ./scripts/build_and_parse_hm_options.rb
         
-      - name: extract-options-release-24.05 (stable)
+      - name: extract-options-release-24.11 (old-stable)
         env:
-          HM_RELEASE: release-24.05
+          HM_RELEASE: release-24.11
         run: ./scripts/build_and_parse_hm_options.rb
 
       - name: Build Hugo


### PR DESCRIPTION
The changes to the main source change the site code but don't generate the new json file. I want to fix the caching errors too, but maybe in a follow-up PR.